### PR TITLE
Remove invalid revert-buffer-function

### DIFF
--- a/navi-mode.el
+++ b/navi-mode.el
@@ -283,8 +283,7 @@
 
 ;;; Mode Definitions
 
-(define-derived-mode navi-mode
-  occur-mode "Navi"
+(define-derived-mode navi-mode occur-mode "Navi"
   "Major mode for easy buffer-navigation.
 In this mode (derived from `occur-mode') you can easily navigate
 in an associated original-buffer via one-key commands in the
@@ -295,9 +294,7 @@ especially useful in buffers with outline structure, e.g. buffers
 with `outline-minor-mode' activated and `outshine' extensions
 loaded.
 \\{navi-mode-map}"
-  (set (make-local-variable 'revert-buffer-function) 'navi-revert-function)
-  ;; (setq case-fold-search nil)
-  )
+  (setq revert-buffer-function 'navi-revert-buffer-function))
 
 (define-derived-mode navi-edit-mode navi-mode "Navi-Edit"
   "Major mode for editing *Navi* buffers.
@@ -1568,6 +1565,13 @@ FUN-NO-PREFIX, otherwise add `outshine-' prefix and thus call the
         (eq major-mode 'navi-mode) (navi-mode))
     (goto-char
      (navi-search-less-or-equal-line-number))))
+
+(defun navi-revert-buffer-function (&optional _ignore-auto noconfirm)
+  "Wrapper for `revert-buffer-function'."
+  (when (or noconfirm
+            revert-without-query
+            (y-or-n-p "revert Navi buffer?"))
+    (navi-revert-function)))
 
 ;;;;; Navi Generic Command
 


### PR DESCRIPTION
Fixes #6. We could change `navi-revert-function` to match the signature of `revert-buffer` but that would require some refactoring because there is no regexp argument. However since reverting is only one key away, and since as the wiki says, you will rarely need to do this, it seems better to just remove this override. 