### PR TITLE
Adjust autoloads to better support org-mode

### DIFF
--- a/navi-mode.el
+++ b/navi-mode.el
@@ -1425,6 +1425,8 @@ Set this to a list of MAX-LEVEL headings as they are matched by
 Regexp should result in an occur-search showing up to
 outline-level LEVEL headlines in navi-buffer. If NO-PARENT-LEVELS
 in non-nil, only headers of level LEVEL are shown."
+  (unless outshine-promotion-headings
+    (navi-make-org-mode-promotion-headings-list))
   (if (not (and level
                 (integer-or-marker-p level)
                 (>= level 1)


### PR DESCRIPTION
Suppose we rely on autoloading `navi`, and we open an `org-mode` file. If we try
calling (the autoloaded function) `navi-search-and-switch`, we'll get a cryptic
error about strings. This is because the local variable
`outshine-promotion-headings` has not been set, and `navi` needs this to
construct its regexp. Normally, this is handled by the addition of
`navi-make-org-mode-promotion-headings-list` to the `org-mode-hook`; however,
this doesn't occur until *after* `navi-mode` has been loaded, which
happens *after* we loaded our org-mode file.

This commit fixes this by
1) autoloading `navi-make-org-mode-promotion-headings-list`
2) using an autoload directive so that during autoloading, navi manipulates
`org-mode-hook` to include
`navi-make-org-mode-promotion-headings-list` (rather than waiting to do this
until `navi-mode` is itself loaded)
3) switching the deprecated usage of `org-add-hook` to `add-hook` so that the
step above works even if `org-add-hook` hasn't yet been defined

In `navi-mode`'s defense, the documentation does suggest including
```
(require 'navi-mode)
```
in the user's config. If this advice is followed, then `navi-mode` should
already manipulated the `org-mode-hook` prior to opening any `org-mode` files
and we should be all set. However, since `navi-mode` already uses some
autoloading, it seemed natural to make it more robust.